### PR TITLE
Orange pi 4.6

### DIFF
--- a/Documentation/devicetree/bindings/pwm/pwm-sun4i.txt
+++ b/Documentation/devicetree/bindings/pwm/pwm-sun4i.txt
@@ -6,6 +6,7 @@ Required properties:
     - "allwinner,sun5i-a10s-pwm"
     - "allwinner,sun5i-a13-pwm"
     - "allwinner,sun7i-a20-pwm"
+    - "allwinner,sun8i-h3-pwm"
   - reg: physical base address and length of the controller's registers
   - #pwm-cells: should be 3. See pwm.txt in this directory for a description of
     the cells format.

--- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo-epc.dts
+++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo-epc.dts
@@ -40,8 +40,15 @@
  *     OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Changelog
+ * 2016.11.12 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * include sun8i-h3-nanopi-neo.dts
+ * 2016.11.10 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * created, LEDs added, RTC via I2C added
+ */
 
-#include "sun8i-h3-nanopi.dtsi"
+#include "sun8i-h3-nanopi-neo.dts"
  
 / {
 	model = "FriendlyARM NanoPi NEO / ePC NEO by e-design";
@@ -61,6 +68,8 @@
 		sys0 {
 			label = "epc:yellow:sys";
 			gpios = <&pio 0 6 GPIO_ACTIVE_LOW>; /*GPIOA6*/
+			//pwms = <&pwm 1 5000000>;
+			max-brightness = <255>;
 			linux,default-trigger = "heartbeat";
 		};
 		sys1 {
@@ -105,17 +114,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x68>;
-	};
-};
-
-&emac {
-	phy = <&phy1>;
-	phy-mode = "mii";
-	allwinner,use-internal-phy;
-	allwinner,leds-active-low;
-	status = "okay";
-	phy1: ethernet-phy@1 {
-		reg = <1>;
 	};
 };
 

--- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
+++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
@@ -40,12 +40,107 @@
  *     OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Changelog
+ * 2016.11.12 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * VDO via GPIOL6 added (0=1.1V, 1=1.3V)
+ *   * CPU freq table added
+ * 2016.11.10 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * ethernet added / enabled
+ */
 
 #include "sun8i-h3-nanopi.dtsi"
  
 / {
 	model = "FriendlyARM NanoPi NEO";
 	compatible = "friendlyarm,nanopi-neo", "allwinner,sun8i-h3";
+	
+	vdd_cpux: gpio-regulator {
+		compatible = "regulator-gpio";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&vdd_cpux_r_opc>;
+
+		regulator-name = "vdd-cpux";
+		regulator-type = "voltage";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1300000>;
+		regulator-enable-ramp-delay = <200>; /* 1ms */
+
+		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
+		gpios-states = <0x1>;
+		states = <1100000 0x0
+			  1300000 0x1>;
+	};
+};
+
+
+&cpu0 {
+	operating-points = <
+		1200000	1300000
+		1008000	1300000
+		816000	1100000
+		624000	1100000
+		480000	1100000
+		312000	1100000
+		240000	1100000
+		120000	1100000
+		>;
+	#cooling-cells = <2>;
+	cooling-min-level = <0>;
+	cooling-max-level = <7>;
+	cpu0-supply = <&vdd_cpux>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_warm: cpu_warm {
+			temperature = <65000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_hot: cpu_hot {
+			temperature = <75000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_very_hot: cpu_very_hot {
+			temperature = <90000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_crit: cpu_crit {
+			temperature = <105000>;
+			hysteresis = <2000>;
+			type = "critical";
+		};
+	};
+
+	cooling-maps {
+		cpu_warm_limit_cpu {
+			trip = <&cpu_warm>;
+			cooling-device = <&cpu0 THERMAL_NO_LIMIT 2>;
+		};
+		cpu_hot_limit_cpu {
+			trip = <&cpu_hot>;
+			cooling-device = <&cpu0 2 4>;
+		};
+		cpu_very_hot_limit_cpu {
+			trip = <&cpu_very_hot>;
+			cooling-device = <&cpu0 6 THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&r_pio {
+	vdd_cpux_r_opc: regulator_pins@0 {
+		allwinner,pins = "PL6";
+		allwinner,function = "gpio_out";
+		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+	};
 };
 
 &emac {
@@ -58,4 +153,5 @@
 		reg = <1>;
 	};
 };
+
 

--- a/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi
+++ b/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi
@@ -40,6 +40,17 @@
  *     OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Changelog
+ * 2016.11.12 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * include thermal
+ *   * TODO: check for nanopi-neo air hardware and move items from nanopi-neo.dts in here
+ * 2016.11.10 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * heartbeat trigger for LED nanopi:blue:status added
+ *   * I2C added
+ */
+
+
 /dts-v1/;
 #include "sun8i-h3.dtsi"
 #include "sunxi-common-regulators.dtsi"
@@ -47,6 +58,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/sun4i-a10.h>
+#include <dt-bindings/thermal/thermal.h>
 
 / {
 	aliases {
@@ -125,12 +137,14 @@
 		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 	};
 
+	/*
 	sw_r_npi: key_pins@0 {
 		allwinner,pins = "PL3";
 		allwinner,function = "gpio_in";
 		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 	};
+	*/
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/sun8i-h3.dtsi
+++ b/arch/arm/boot/dts/sun8i-h3.dtsi
@@ -40,6 +40,16 @@
  *     OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Changelog
+ * 2016.11.12 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * PWM0 & PWM1  added
+ * 2016.11.10 Alexander Krause <alexander.krause at ed-solutions dot de>
+ *   * I2C added
+ *   * UARTs added
+ */
+
+
 #include "skeleton.dtsi"
 
 #include <dt-bindings/interrupt-controller/arm-gic.h>
@@ -534,6 +544,14 @@
 				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 			};
 
+			pwm0_pin: pwm0@0 {
+				/* conflicts with UART0RX */
+				allwinner,pins = "PA5";
+				allwinner,function = "pwm0";
+				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+			};
+
 			uart0_pins_a: uart0@0 {
 				allwinner,pins = "PA4", "PA5";
 				allwinner,function = "uart0";
@@ -661,6 +679,14 @@
 			clock-names = "ahb", "ths";
 		};
 
+		pwm: pwm@01c21400 {
+			compatible = "allwinner,sun8i-h3-pwm";
+			reg = <0x01c21400 0x8>;
+			clocks = <&osc24M>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+		
 		uart0: serial@01c28000 {
 			compatible = "snps,dw-apb-uart";
 			reg = <0x01c28000 0x400>;

--- a/drivers/pwm/pwm-sun4i.c
+++ b/drivers/pwm/pwm-sun4i.c
@@ -284,6 +284,12 @@ static const struct sun4i_pwm_data sun4i_pwm_data_a20 = {
 	.npwm = 2,
 };
 
+static const struct sun4i_pwm_data sun4i_pwm_data_h3 = {
+	.has_prescaler_bypass = true,
+	.has_rdy = true,
+	.npwm = 1,
+};
+
 static const struct of_device_id sun4i_pwm_dt_ids[] = {
 	{
 		.compatible = "allwinner,sun4i-a10-pwm",
@@ -297,6 +303,9 @@ static const struct of_device_id sun4i_pwm_dt_ids[] = {
 	}, {
 		.compatible = "allwinner,sun7i-a20-pwm",
 		.data = &sun4i_pwm_data_a20,
+	}, {
+		.compatible = "allwinner,sun8i-h3-pwm",
+		.data = &sun4i_pwm_data_h3,
 	}, {
 		/* sentinel */
 	},


### PR DESCRIPTION
  * adds support for PWM0 on H3 boards
  * adds CPU frequency table with VDO for NanoPi NEO (tested)

Basically the NEO has the same VDO setup like orangepi-one. The VDO can create 1.1V or 1.3V so the frequency table should fit too.

Also the temperature listed in thermal_zone0 looks good.

PWM0 however would use USART0/RX IO which activation doesn't make much sense.