### PR TITLE
Add OrangePi Zero CPU frequency scaling

### DIFF
--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
@@ -49,10 +49,11 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/thermal/thermal.h>
 
 / {
 	model = "Xunlong Orange Pi Zero";
-	compatible = "xunlong,orangepi-zero", "allwinner,sun8i-h2-plus";
+	compatible = "xunlong,orangepi-zero", "allwinner,sun8i-h2-plus", "allwinner,sun8i-h3";
 
 	aliases {
 		serial0 = &uart0;
@@ -93,6 +94,77 @@
 		compatible = "mmc-pwrseq-simple";
 		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
 		post-power-on-delay-ms = <200>;
+	};
+
+	vdd_cpux: gpio-regulator {
+		compatible = "regulator-gpio";
+		regulator-name = "vdd-cpux";
+		regulator-type = "voltage";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1300000>;
+		regulator-ramp-delay = <50>; /* 4ms */
+		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
+		gpios-states = <0x1>;
+		states = <1100000 0x0
+			  1300000 0x1>;
+	};
+};
+
+&cpu0 {
+	operating-points = <
+		1008000	1100000
+		816000	1100000
+		624000	1100000
+		480000	1100000
+		312000	1100000
+		240000	1100000
+		120000	1100000
+		>;
+	#cooling-cells = <2>;
+	cooling-min-level = <0>;
+	cooling-max-level = <6>;
+	cpu0-supply = <&vdd_cpux>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_warm: cpu_warm {
+			temperature = <65000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_hot: cpu_hot {
+			temperature = <75000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_very_hot: cpu_very_hot {
+			temperature = <90000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+		cpu_crit: cpu_crit {
+			temperature = <105000>;
+			hysteresis = <2000>;
+			type = "critical";
+		};
+	};
+
+	cooling-maps {
+		cpu_warm_limit_cpu {
+			trip = <&cpu_warm>;
+			cooling-device = <&cpu0 THERMAL_NO_LIMIT 2>;
+		};
+		cpu_hot_limit_cpu {
+			trip = <&cpu_hot>;
+			cooling-device = <&cpu0 3 4>;
+		};
+		cpu_very_hot_limit_cpu {
+			trip = <&cpu_very_hot>;
+			cooling-device = <&cpu0 5 THERMAL_NO_LIMIT>;
+		};
 	};
 };
 


### PR DESCRIPTION
Based on original patch by Igor Pečovnik (@igorpecovnik) for Armbian
(https://github.com/armbian/build/commit/506fa69515c6de4ac0a811d4d986001da61aad13).

Adds the necessary data to DTB to let the CPU prevent overheating
by reducing the frequency under heavy CPU loads and/or hard
temperature environment.

The settings are slightly modified to make cooling more aggressive
in intermediate modes, as original settings still lead to overheating
hangs in some rare cases. More info on temperature conditions and
some estimates (in Russian):
http://4pda.ru/forum/index.php?showtopic=782242&st=780#entry57751280

The modified settings are tested under moderate and heavy load
(rebuilding the world) with aluminium radiator on the CPU and
OrangePi Zero installed in its original case.