### PR TITLE
arm64: dts: rk3399-pinephone-pro: Add correct camera rotation values

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
@@ -890,6 +890,7 @@
 		reset-gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_LOW>;
 		powerdown-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
 
+		orientation = <1>;
 		rotation = <270>;
 
 		lens-focus = <&wcam_lens>;
@@ -930,6 +931,7 @@
 		rockchip,camera-module-name = "CameraKing";
 		rockchip,camera-module-lens-name = "Largan-9569A2";
 
+		orientation = <0>;
 		rotation = <90>;
 
 		port {


### PR DESCRIPTION
### Depends on https://github.com/megous/linux/pull/18

According to the documentation at
Documentation/userspace-api/media/v4l/ext-ctrls-camera.rst#V4L2_CID_CAMERA_SENSOR_ROTATION These values are also used by Megapixels, see [1].

The values have been also been verified with pending libcamera patches[2], the new Pipewire transform support[3] and the Gstreamer-based "Camera" app[4][5] (the possible "gnome-camera" candidate).

Note: the drivers do not yet support exposing these values via the `V4L2_CID_CAMERA_SENSOR_ROTATION` API, patches for that will follow.

The motivation is to let the future camera stack, consisting of libcamera, Pipewire, xdg-camera-portal and [Gstreamer|libwebrtc|obs-studio|...] properly find the correct camera rotation and adjust the visual results accordingly.

While on it, also add 'orientation' values for front and back.

1: https://github.com/kgmt0/megapixels/blob/3dc718a0626fb89b364b468ba85d9aded41e2f91/config/pine64,pinephone-pro.ini 2: https://patchwork.libcamera.org/patch/17891/
3: https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1457 4: https://gitlab.gnome.org/jwestman/libaperture/-/merge_requests/22 5: https://gitlab.gnome.org/jwestman/camera

Signed-off-by: Robert Mader <robert.mader@posteo.de>

---

How to validate: The outputs of the following commands should change from
```
xxd -g4 /proc/device-tree/i2c@ff110000/camera@1a/rotation 
00000000: 000000b4
xxd -g4 /proc/device-tree/i2c@ff110000/camera@36/rotation 
00000000: 000000b4
```

to
```
xxd -g4 /proc/device-tree/i2c@ff110000/camera@1a/rotation 
00000000: 0000010e
xxd -g4 /proc/device-tree/i2c@ff110000/camera@36/rotation 
00000000: 0000005a
```