### PR TITLE
Add mount-matrix of the PinePhone Pro magnetometer

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
@@ -1076,6 +1076,11 @@
 		reset-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_LOW>;
 		avdd-supply = <&vcc_3v0>;
 		dvdd-supply = <&vcc_1v8>;
+		
+		mount-matrix =
+			"0", "1", "0",
+			"-1", "0", "0",
+			"0", "0", "1";
 	};
 };
 


### PR DESCRIPTION
After experimenting with the magnetometer on the Pinephone Pro I found out the mount-matrix currently reported by the AF8133J driver is just the identity matrix (no rotation), which is wrong. It would seem to me that there is currently no `mount-matrix` info and that's why the driver reports a trivial answer. As far as I can tell from my tests, a 90 degree clockwise rotation in the XY plane would align it properly. 

I don't know if this is the proper place (as in this repo/branch) to submit this, or whether this is the correct place (as in the code) to make this change. I am not an expert but I just wanted to contribute by fixing this.