### PR TITLE
arm64: dts: rk3588-orange-pi-5-plus: enable pwm-fan

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
@@ -326,6 +326,56 @@
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
 };
 
+&soc_thermal {
+	trips {
+		cpu_temp_1: cpu_temp_1 {
+			temperature = <55000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_temp_2: cpu_temp_2 {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_temp_3: cpu_temp_3 {
+			temperature = <65000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_temp_4: cpu_temp_4 {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map1 {
+			trip = <&cpu_temp_1>;
+			cooling-device = <&fan 0 1>;
+		};
+
+		map2 {
+			trip = <&cpu_temp_2>;
+			cooling-device = <&fan 1 2>;
+		};
+
+		map3 {
+			trip = <&cpu_temp_3>;
+			cooling-device = <&fan 2 3>;
+		};
+
+		map4 {
+			trip = <&cpu_temp_4>;
+			cooling-device = <&fan 3 4>;
+		};
+	};
+};
+
 &u2phy2 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
@@ -74,6 +74,14 @@
 		};
 	};
 
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		cooling-levels = <0 70 75 80 100>;
+		fan-supply = <&vcc5v0_sys>;
+		pwms = <&pwm3 0 50000 0>;
+		#cooling-cells = <2>;
+	};
+
 	ir-receiver {
 		compatible = "gpio-ir-receiver";
 		gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
@@ -487,6 +495,11 @@
 		     &i2s0_sdi0
 		     &i2s0_sdo0>;
 	status = "okay";
+};
+
+&pwm3 {
+	status = "okay";
+	pinctrl-0 = <&pwm3m1_pins>;
 };
 
 &pinctrl {


### PR DESCRIPTION
Hey, firstly, thanks so much for this branch! Great as the board is, it was somewhat concerning that it seems to be stuck on 5.10 on the official builds so it's good that it can be kept up to date with the latest kernel versions, hopefully it'll get added to mainline at some point too

I used the cooling levels from `rk3588-rock-5b.dts` but the xunlong 5.10 branch uses `pwm3` and `pinctrl-0 = <&pwm3m1_pins>;` so used those here also as their definitions look the same between this branch and xunlong's.
I haven't messed with dtb's before so there maybe something  as the fan does spin up on boot, but for some reason the speed only changes between `68` , when it goes completely off, and `80`, which sounds like the same speed as the max value `255` when i set those values in `/sys/devices/platform/pwm-fan/hwmon/hwmon8/pwm1`

 Not sure if you have any ideas why that is?