### PR TITLE
arm64: dts: rk3588-orange-pi-5-plus: enable pcie wlan

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orange-pi-5-plus.dts
@@ -276,6 +276,13 @@
 		startup-delay-us = <5000>;
 		vin-supply = <&vcc5v0_sys>;
 	};
+
+	rfkill_wlan: rfkill {
+		compatible = "rfkill-gpio";
+		label = "rfkill-pcie-wlan";
+		radio-type = "wlan";
+		shutdown-gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &cpu_b0 {


### PR DESCRIPTION
Copied these in from the xunlong device tree and wifi is now working with an m.2 2230 card. Before these changes, the device would be detected, correct kernel module loaded and appear in `ip a`, but would always return `Hard blocked: yes` from `rfkill` so was unusable.